### PR TITLE
неверное декодирование приводит в ошибочному определению длины строки

### DIFF
--- a/src/Header/HeaderWrap.php
+++ b/src/Header/HeaderWrap.php
@@ -164,7 +164,7 @@ abstract class HeaderWrap
             'line-length' => $lineLength,
         ];
 //dump($value);
-        $encoded = @iconv_mime_encode('x-test', $value, $preferences);
+        $encoded = preg_replace('/^:\s+/', '', @iconv_mime_encode("x-test", $value, $preferences));
 
         return (false !== $encoded);
     }


### PR DESCRIPTION
iconv_mime_encode () не подходит напрямую для кодирования заголовков, которые включают "специальные" символы, например, как описано в RFC 1522 s4 и s5.

Кроме того, значения "line-length" больше 76 будут недопустимыми в соответствии с RFC 1522, и полученные закодированные слова могут не распознаваться. 

https://www.php.net/manual/ru/function.iconv-mime-encode.php